### PR TITLE
fix: handle case when email includes partial provider domain name

### DIFF
--- a/lib/providly.rb
+++ b/lib/providly.rb
@@ -3,7 +3,7 @@ Gem.find_files('providly/**/*.rb').each { |file| require file }
 module Providly
   def self.email_uses_provider?(email)
     provider_domains = read_provider_domains
-    !provider_domains.select { |domain| email.include?(domain) }.empty?
+    !provider_domains.select { |domain| email.split("@").last == domain }.empty?
   end
 
   private

--- a/spec/providly_spec.rb
+++ b/spec/providly_spec.rb
@@ -8,6 +8,10 @@ describe Providly do
   describe '#email_uses_provider?' do
     it { expect(Providly.email_uses_provider? 'email@gmail.com').to be true }
     it { expect(Providly.email_uses_provider? 'email@elcurator.net').to be false }
+
+    it 'deals with email domain that includew provider_domain' do
+      expect(Providly.email_uses_provider? 'email@analytics.com').to be false
+    end
   end
 
   describe '#read_provider_domains' do


### PR DESCRIPTION
A bug was reported by a user when trying to sign in with his professional email address.

The user was using a professional email address, such as `name@analytics.com`, but he could not sign in as his email was rejected.

This email address was considered as a provider email address (and not a professional one) as it includes the letters `cs.com`;  `cs.com` being listed as a provider domain.

```ruby
email.include?(domain)

#=> return TRUE for "name@analytics.com".include?("cs.com")
```
